### PR TITLE
Add fix to FindUUID to avoid spurious dependencies on libuuid on macOS

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '10'
+- '11'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '10'
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/recipe/FindUUID.cmake.patch
+++ b/recipe/FindUUID.cmake.patch
@@ -1,0 +1,105 @@
+From 5cf1583efaa4742d8bf9e405f47956c506546a25 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Sun, 15 Nov 2020 23:25:17 +0100
+Subject: [PATCH] FindUUID: Always define UUID::UUID on Apple platforms
+
+On Apple platforms, the headers of libuuid and its symbols
+are provided by the OS SDK, so no further linking is necessary.
+
+Fix https://github.com/ignitionrobotics/ign-cmake/issues/127
+
+Signed-off-by: Silvio Traversaro <silvio.traversaro@iit.it>
+---
+ cmake/FindUUID.cmake | 79 ++++++++++++++++++++++++--------------------
+ 1 file changed, 43 insertions(+), 36 deletions(-)
+
+diff --git a/cmake/FindUUID.cmake b/cmake/FindUUID.cmake
+index 54246ed..94a6c16 100644
+--- a/cmake/FindUUID.cmake
++++ b/cmake/FindUUID.cmake
+@@ -16,42 +16,49 @@
+ ########################################
+ # Find uuid
+ if (UNIX)
+-  include(IgnPkgConfig)
+-  ign_pkg_check_modules_quiet(UUID uuid)
+-
+-  if(NOT UUID_FOUND)
+-    include(IgnManualSearch)
+-    ign_manual_search(UUID
+-                      HEADER_NAMES "uuid.h"
+-                      LIBRARY_NAMES "uuid libuuid"
+-                      PATH_SUFFIXES "uuid")
+-  endif()
+-
+-  # The pkg-config or the manual search will place
+-  # <uuid_install_prefix>/include/uuid in INTERFACE_INCLUDE_DIRECTORIES,
+-  # but some projects exepect to use <uuid_install_prefix>/include, so
+-  # we add it as well.
+-  # See https://github.com/ignitionrobotics/ign-cmake/issues/103
+-  if(TARGET UUID::UUID)
+-    get_property(uuid_include_dirs
+-      TARGET UUID::UUID
+-      PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+-
+-    set(uuid_include_dirs_extended ${uuid_include_dirs})
+-
+-    foreach(include_dir IN LISTS uuid_include_dirs)
+-      if(include_dir MATCHES "uuid$")
+-        get_filename_component(include_dir_parent ${include_dir} DIRECTORY)
+-        list(APPEND uuid_include_dirs_extended ${include_dir_parent})
+-      endif()
+-    endforeach()
+-
+-    list(REMOVE_DUPLICATES uuid_include_dirs_extended)
+-
+-    set_property(
+-      TARGET UUID::UUID
+-      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+-      ${uuid_include_dirs_extended})
++  if(NOT APPLE)
++    include(IgnPkgConfig)
++    ign_pkg_check_modules_quiet(UUID uuid)
++    
++    if(NOT UUID_FOUND)
++      include(IgnManualSearch)
++      ign_manual_search(UUID
++                        HEADER_NAMES "uuid.h"
++                        LIBRARY_NAMES "uuid libuuid"
++                        PATH_SUFFIXES "uuid")
++    endif()
++    
++    # The pkg-config or the manual search will place
++    # <uuid_install_prefix>/include/uuid in INTERFACE_INCLUDE_DIRECTORIES,
++    # but some projects exepect to use <uuid_install_prefix>/include, so
++    # we add it as well.
++    # See https://github.com/ignitionrobotics/ign-cmake/issues/103
++    if(TARGET UUID::UUID)
++      get_property(uuid_include_dirs
++        TARGET UUID::UUID
++        PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
++    
++      set(uuid_include_dirs_extended ${uuid_include_dirs})
++    
++      foreach(include_dir IN LISTS uuid_include_dirs)
++        if(include_dir MATCHES "uuid$")
++          get_filename_component(include_dir_parent ${include_dir} DIRECTORY)
++          list(APPEND uuid_include_dirs_extended ${include_dir_parent})
++        endif()
++      endforeach()
++    
++      list(REMOVE_DUPLICATES uuid_include_dirs_extended)
++    
++      set_property(
++        TARGET UUID::UUID
++        PROPERTY INTERFACE_INCLUDE_DIRECTORIES
++        ${uuid_include_dirs_extended})
++    endif()
++  else()
++    # On Apple platforms the UUID library is provided by the OS SDK
++    # See https://github.com/ignitionrobotics/ign-cmake/issues/127
++    set(UUID_FOUND TRUE)
++    add_library(UUID::UUID INTERFACE IMPORTED)
+   endif()
+ 
+   include(FindPackageHandleStandardArgs)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - examples.patch  # [linux]
       - FindGTS.cmake.patch  # [win]
       - FindIgnOGRE.cmake.patch  # [win]
-      - FindUUID.cmake.patch
+      - FindUUID.cmake.patch  # [osx]
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,10 @@ source:
       - examples.patch  # [linux]
       - FindGTS.cmake.patch  # [win]
       - FindIgnOGRE.cmake.patch  # [win]
+      - FindUUID.cmake.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}


### PR DESCRIPTION
Backport of https://github.com/ignitionrobotics/ign-cmake/pull/128

Fix of the problems reported in https://github.com/conda-forge/libuuid-feedstock/issues/16 for Ignition libraries.
Fix (once all the affected ignition libraries are rebuilt) the compilation failure in https://github.com/robotology/robotology-superbuild/pull/513 . 

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
