### PR TITLE
Fix error in the patch for FindUUID on macOS

### DIFF
--- a/recipe/FindUUID.cmake.patch
+++ b/recipe/FindUUID.cmake.patch
@@ -1,4 +1,4 @@
-From 5cf1583efaa4742d8bf9e405f47956c506546a25 Mon Sep 17 00:00:00 2001
+From 73a52ad6ac5f049f79a4cecb460ce112feae248e Mon Sep 17 00:00:00 2001
 From: Silvio Traversaro <silvio.traversaro@iit.it>
 Date: Sun, 15 Nov 2020 23:25:17 +0100
 Subject: [PATCH] FindUUID: Always define UUID::UUID on Apple platforms
@@ -10,20 +10,23 @@ Fix https://github.com/ignitionrobotics/ign-cmake/issues/127
 
 Signed-off-by: Silvio Traversaro <silvio.traversaro@iit.it>
 ---
- cmake/FindUUID.cmake | 79 ++++++++++++++++++++++++--------------------
- 1 file changed, 43 insertions(+), 36 deletions(-)
+ cmake/FindUUID.cmake | 69 +++++++++++++++++++++++++-------------------
+ 1 file changed, 39 insertions(+), 30 deletions(-)
 
 diff --git a/cmake/FindUUID.cmake b/cmake/FindUUID.cmake
-index 54246ed..94a6c16 100644
+index 54246ed..e28ccfb 100644
 --- a/cmake/FindUUID.cmake
 +++ b/cmake/FindUUID.cmake
-@@ -16,42 +16,49 @@
+@@ -16,42 +16,51 @@
  ########################################
  # Find uuid
  if (UNIX)
 -  include(IgnPkgConfig)
 -  ign_pkg_check_modules_quiet(UUID uuid)
--
++  if(NOT APPLE)
++    include(IgnPkgConfig)
++    ign_pkg_check_modules_quiet(UUID uuid)
+ 
 -  if(NOT UUID_FOUND)
 -    include(IgnManualSearch)
 -    ign_manual_search(UUID
@@ -31,7 +34,14 @@ index 54246ed..94a6c16 100644
 -                      LIBRARY_NAMES "uuid libuuid"
 -                      PATH_SUFFIXES "uuid")
 -  endif()
--
++    if(NOT UUID_FOUND)
++      include(IgnManualSearch)
++      ign_manual_search(UUID
++                        HEADER_NAMES "uuid.h"
++                        LIBRARY_NAMES "uuid libuuid"
++                        PATH_SUFFIXES "uuid")
++    endif()
+ 
 -  # The pkg-config or the manual search will place
 -  # <uuid_install_prefix>/include/uuid in INTERFACE_INCLUDE_DIRECTORIES,
 -  # but some projects exepect to use <uuid_install_prefix>/include, so
@@ -41,34 +51,6 @@ index 54246ed..94a6c16 100644
 -    get_property(uuid_include_dirs
 -      TARGET UUID::UUID
 -      PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
--
--    set(uuid_include_dirs_extended ${uuid_include_dirs})
--
--    foreach(include_dir IN LISTS uuid_include_dirs)
--      if(include_dir MATCHES "uuid$")
--        get_filename_component(include_dir_parent ${include_dir} DIRECTORY)
--        list(APPEND uuid_include_dirs_extended ${include_dir_parent})
--      endif()
--    endforeach()
--
--    list(REMOVE_DUPLICATES uuid_include_dirs_extended)
--
--    set_property(
--      TARGET UUID::UUID
--      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
--      ${uuid_include_dirs_extended})
-+  if(NOT APPLE)
-+    include(IgnPkgConfig)
-+    ign_pkg_check_modules_quiet(UUID uuid)
-+    
-+    if(NOT UUID_FOUND)
-+      include(IgnManualSearch)
-+      ign_manual_search(UUID
-+                        HEADER_NAMES "uuid.h"
-+                        LIBRARY_NAMES "uuid libuuid"
-+                        PATH_SUFFIXES "uuid")
-+    endif()
-+    
 +    # The pkg-config or the manual search will place
 +    # <uuid_install_prefix>/include/uuid in INTERFACE_INCLUDE_DIRECTORIES,
 +    # but some projects exepect to use <uuid_install_prefix>/include, so
@@ -78,18 +60,30 @@ index 54246ed..94a6c16 100644
 +      get_property(uuid_include_dirs
 +        TARGET UUID::UUID
 +        PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-+    
+ 
+-    set(uuid_include_dirs_extended ${uuid_include_dirs})
 +      set(uuid_include_dirs_extended ${uuid_include_dirs})
-+    
+ 
+-    foreach(include_dir IN LISTS uuid_include_dirs)
+-      if(include_dir MATCHES "uuid$")
+-        get_filename_component(include_dir_parent ${include_dir} DIRECTORY)
+-        list(APPEND uuid_include_dirs_extended ${include_dir_parent})
+-      endif()
+-    endforeach()
 +      foreach(include_dir IN LISTS uuid_include_dirs)
 +        if(include_dir MATCHES "uuid$")
 +          get_filename_component(include_dir_parent ${include_dir} DIRECTORY)
 +          list(APPEND uuid_include_dirs_extended ${include_dir_parent})
 +        endif()
 +      endforeach()
-+    
+ 
+-    list(REMOVE_DUPLICATES uuid_include_dirs_extended)
 +      list(REMOVE_DUPLICATES uuid_include_dirs_extended)
-+    
+ 
+-    set_property(
+-      TARGET UUID::UUID
+-      PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+-      ${uuid_include_dirs_extended})
 +      set_property(
 +        TARGET UUID::UUID
 +        PROPERTY INTERFACE_INCLUDE_DIRECTORIES
@@ -99,7 +93,9 @@ index 54246ed..94a6c16 100644
 +    # On Apple platforms the UUID library is provided by the OS SDK
 +    # See https://github.com/ignitionrobotics/ign-cmake/issues/127
 +    set(UUID_FOUND TRUE)
-+    add_library(UUID::UUID INTERFACE IMPORTED)
++    if(NOT TARGET UUID::UUID)
++      add_library(UUID::UUID INTERFACE IMPORTED)
++    endif()
    endif()
  
    include(FindPackageHandleStandardArgs)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
       - FindUUID.cmake.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}


### PR DESCRIPTION
The previous patch created a failure if find_package(UUID) was called twice, and resulted in this error:
~~~
2020-11-17T20:31:22.6139260Z CMake Error at /usr/local/miniconda/envs/test/share/cmake/ignition-cmake2/cmake2/FindUUID.cmake:61 (add_library):
2020-11-17T20:31:22.6140410Z   add_library cannot create imported target "UUID::UUID" because another
2020-11-17T20:31:22.6141100Z   target with the same name already exists.
~~~

See https://github.com/ignitionrobotics/ign-cmake/pull/128#issuecomment-729246922 .

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
