### PR TITLE
Fix problems in finding UUID on Linux when pkg-config is not installed 

### DIFF
--- a/recipe/315.patch
+++ b/recipe/315.patch
@@ -1,0 +1,17 @@
+diff --git a/cmake/FindUUID.cmake b/cmake/FindUUID.cmake
+index e28ccfbb..bf26039c 100644
+--- a/cmake/FindUUID.cmake
++++ b/cmake/FindUUID.cmake
+@@ -23,9 +23,9 @@ if (UNIX)
+     if(NOT UUID_FOUND)
+       include(IgnManualSearch)
+       ign_manual_search(UUID
+-                        HEADER_NAMES "uuid.h"
+-                        LIBRARY_NAMES "uuid libuuid"
+-                        PATH_SUFFIXES "uuid")
++                        HEADER_NAMES uuid.h
++                        LIBRARY_NAMES uuid libuuid
++                        PATH_SUFFIXES uuid)
+     endif()
+ 
+     # The pkg-config or the manual search will place

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
       - 315.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ package:
 source:
   - url: https://github.com/ignitionrobotics/ign-cmake/archive/ignition-cmake{{ major_version }}_{{ version }}.tar.gz
     sha256: e89e72bbf9d3ba27442db76478f68a1e56cf280b33c79cdcf23d7a13ea35980d
+    patches:
+      - 315.patch
 
 build:
   number: 0


### PR DESCRIPTION
Fix https://github.com/conda-forge/libignition-cmake0-feedstock/issues/32 by backporting https://github.com/gazebosim/gz-cmake/pull/315 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
