### PR TITLE
Fix FindAVDEVICE.cmake in case without pkg-config installed with ffmpeg >= 5.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,6 +14,7 @@ jobs:
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\
+    UPLOAD_TEMP: D:\\tmp
 
   steps:
     - task: PythonScript@0
@@ -72,6 +73,9 @@ jobs:
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         set "FEEDSTOCK_NAME=%BUILD_REPOSITORY_NAME:*/=%"
+        set "TEMP=$(UPLOAD_TEMP)"
+        if not exist "%TEMP%\" md "%TEMP%"
+        set "TMP=%TEMP%"
         call activate base
         upload_package --validate --feedstock-name="%FEEDSTOCK_NAME%" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 target_platform:

--- a/recipe/330.patch
+++ b/recipe/330.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/FindAVDEVICE.cmake b/cmake/FindAVDEVICE.cmake
+index c681bf2b..495050f8 100644
+--- a/cmake/FindAVDEVICE.cmake
++++ b/cmake/FindAVDEVICE.cmake
+@@ -32,6 +32,13 @@ if(NOT AVDEVICE_FOUND)
+   if(AVDEVICE_FOUND)
+     file(READ "${AVDEVICE_INCLUDE_DIRS}/libavdevice/version.h" ver_file)
+ 
++    # ffmpeg 5.1 splitted version information in two files
++    # https://github.com/FFmpeg/FFmpeg/commit/884c5976592c2d8084e8c9951c94ddf04019d81d
++    if(EXISTS "${AVDEVICE_INCLUDE_DIRS}/libavdevice/version_major.h")
++      file(READ "${AVDEVICE_INCLUDE_DIRS}/libavdevice/version_major.h" ver_major_file)
++      string(CONCAT ver_file ${ver_file} ${ver_major_file})
++    endif()
++
+     string(REGEX MATCH "LIBAVDEVICE_VERSION_MAJOR[ \t\r\n]+([0-9]*)" _ ${ver_file})
+     set(ver_major ${CMAKE_MATCH_1})
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,11 @@ package:
 source:
   - url: https://github.com/ignitionrobotics/ign-cmake/archive/ignition-cmake{{ major_version }}_{{ version }}.tar.gz
     sha256: fcbe3de79b711fff8f8a94f24652e5d0e5d3cac8a79dd8f96e03c4b1886db3cc
-   
-
+    patches:
+      - 330.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
Backport https://github.com/gazebosim/gz-cmake/pull/330 to fix https://github.com/conda-forge/libignition-common-feedstock/issues/58 .

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
